### PR TITLE
Prevent 'too much recursion' error in FF@linux

### DIFF
--- a/modules.js
+++ b/modules.js
@@ -245,13 +245,15 @@ var undef,
                                 provideDecl(decl, exports);
                         });
 
-                        decl.fn.apply(
-                            {
-                                name   : decl.name,
-                                deps   : decl.deps,
-                                global : global
-                            },
-                            depDeclsExports);
+                        nextTick(function() {
+                            decl.fn.apply(
+                                {
+                                    name   : decl.name,
+                                    deps   : decl.deps,
+                                    global : global
+                                },
+                                depDeclsExports);
+                        });
                     });
             },
 


### PR DESCRIPTION
This summer we got error 'too much recursion' in our project that uses bem-core.

This error happens only in Firefox under linux (yeah, Ubuntu) and only if we have lot modules in one file (~200 in our case). 

Delay applying declarations with wrap in `nextTick` fix this problem (this solution was found in https://github.com/pouchdb/pouchdb/issues/1156#issuecomment-31136504). 
